### PR TITLE
prevent overlaps from permalink

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -11,8 +11,8 @@
             q:after { content:"“"; }
 
             .permalink {
-                position: absolute;
-                right: 1em;
+                float: right;
+                margin: 0 1em;
             }
             p.value_explanation {
                 background-color: #F8F8F8;


### PR DESCRIPTION
in manchen Fällen überlappt(e) der Permalink die Beschreibungen der linken Seite in FF bspw. beim Umschalten der Sprache, in Chrome permanent