### PR TITLE
Adding Public Holidays for Romania

### DIFF
--- a/PH_SH_exporter.js
+++ b/PH_SH_exporter.js
@@ -65,8 +65,10 @@ var nominatiom_object = {
     },
     'dk' : {
         'dk': {"place_id":"127691068","licence":"Data © OpenStreetMap contributors, ODbL 1.0. http:\/\/www.openstreetmap.org\/copyright","osm_type":"relation","osm_id":"50046","boundingbox":["54.4516667","57.9524297","7.7153255","15.5530641"],"lat":"55.670249","lon":"10.3333283","display_name":"Denmark","class":"boundary","type":"administrative","importance":0.94221531286648,"icon":"https:\/\/nominatim.openstreetmap.org\/images\/mapicons\/poi_boundary_administrative.p.20.png","address":{"country":"Denmark","country_code":"dk"}}
-     }
-
+    },
+    'ro' : {
+        'ro' : {"place_id":"127691986","licence":"Data © OpenStreetMap contributors, ODbL 1.0. http:\/\/www.openstreetmap.org\/copyright","osm_type":"relation","osm_id":"90689","boundingbox":["43.618682","48.2653964","20.2619773","30.0454257"],"lat":"45.9852129","lon":"24.6859225","display_name":"România","class":"boundary","type":"administrative","importance":0.93930940399775,"icon":"https:\/\/nominatim.openstreetmap.org\/images\/mapicons\/poi_boundary_administrative.p.20.png","address":{"country":"România","country_code":"ro"}}
+    }
 };
 /* }}} */
 

--- a/README.md
+++ b/README.md
@@ -734,6 +734,7 @@ Contributor                                        | Contribution
 [Simon Legner](https://github.com/simon04)         | [Browserified](https://github.com/ypid/opening_hours.js/pull/98) the library and made it work with JOSM.
 [MKnight](https://github.com/dex2000)              | HTML/CSS fixes, testing and suggesting new features … :smile:
 [Niels Elgaard Larsen](https://github.com/elgaard) | Public holidays for Denmark.
+[Adrian Fita](https://github.com/afita/)           | Public holidays for Romania.
 
 ## Credits
 

--- a/opening_hours.js
+++ b/opening_hours.js
@@ -2700,7 +2700,7 @@
                 'Ziua Națională (Ziua Marii Uniri)'              : [ 12,  1 ],
                 'Crăciunul'                                      : [ 12, 25 ],
                 'A doua zi de Crăciun'                           : [ 12, 26 ],
-            },
+            }
         } // }}}
     };
     // }}}

--- a/opening_hours.js
+++ b/opening_hours.js
@@ -2685,6 +2685,23 @@
                 '2. svátek vánoční'                              : [ 12, 26 ],
             },
         }, // }}}
+        'ro': { // {{{
+            'PH': { // https://ro.wikipedia.org/wiki/S%C4%83rb%C4%83tori_publice_%C3%AEn_Rom%C3%A2nia#Zile_oficiale_de_s.C4.83rb.C4.83toare_.C3.AEn_care_nu_se_lucreaz.C4.83
+                'Anul Nou'                                       : [  1,  1 ],
+                'A doua zi de Anul Nou'                          : [  1,  2 ],
+                'Ziua Unirii Principatelor Române (Ziua Unirii)' : [  1,  24 ],
+                'Paștele ortodox'                                : [ 'orthodox easter',  0 ],
+                'A doua zi de Paște ortodox'                     : [ 'orthodox easter',  1 ],
+                'Ziua Muncii'                                    : [  5, 1 ],
+                'Rusaliile'                                      : [ 'orthodox easter', 50 ],
+                'A doua zi de Rusalii'                           : [ 'orthodox easter', 51 ],
+                'Adormirea Maicii Domnului'                      : [  8, 15 ],
+                'Sfântul Apostol Andrei'                         : [ 11, 30 ],
+                'Ziua Națională (Ziua Marii Uniri)'              : [ 12,  1 ],
+                'Crăciunul'                                      : [ 12, 25 ],
+                'A doua zi de Crăciun'                           : [ 12, 26 ],
+            },
+        } // }}}
     };
     // }}}
 


### PR DESCRIPTION
Adding Public Holidays for Romania.

Tests:

```
$ ./PH_SH_exporter.js --verbose --from=2015 --until=2015 --public-holidays --country 'ro' --region 'ro' /tmp/ro_holidays.txt
20150101 Anul Nou
20150102 A doua zi de Anul Nou
20150124 Ziua Unirii Principatelor Române (Ziua Unirii)
20150412 Paștele ortodox
20150413 A doua zi de Paște ortodox
20150501 Ziua Muncii
20150601 Rusaliile
20150602 A doua zi de Rusalii
20150815 Adormirea Maicii Domnului
20151130 Sfântul Apostol Andrei
20151201 Ziua Națională (Ziua Marii Uniri)
20151225 Crăciunul
20151226 A doua zi de Crăciun

$ ./PH_SH_exporter.js --verbose --from=2016 --until=2016 --public-holidays --country 'ro' --region 'ro' /tmp/ro_holidays.txt
20160101 Anul Nou
20160102 A doua zi de Anul Nou
20160124 Ziua Unirii Principatelor Române (Ziua Unirii)
20160501 Paștele ortodox
20160502 A doua zi de Paște ortodox
20160620 Rusaliile
20160621 A doua zi de Rusalii
20160815 Adormirea Maicii Domnului
20161130 Sfântul Apostol Andrei
20161201 Ziua Națională (Ziua Marii Uniri)
20161225 Crăciunul
20161226 A doua zi de Crăciun
```